### PR TITLE
Fix: improvements in relationship detection and multiple mixins

### DIFF
--- a/src/typedal/core.py
+++ b/src/typedal/core.py
@@ -550,6 +550,9 @@ class TypeDAL(pydal.DAL):  # type: ignore
             if k not in relationships and (new_relationship := to_relationship(cls, k, annotations[k]))
         }
 
+        # fixme: list[Reference] is recognized as relationship,
+        #        TypedField(list[Reference]) is NOT recognized!!!
+
         cache_dependency = self._config.caching and kwargs.pop("cache_dependency", True)
 
         table: Table = self.define_table(tablename, *fields.values(), **kwargs)

--- a/src/typedal/core.py
+++ b/src/typedal/core.py
@@ -279,9 +279,10 @@ def relationship(_type: To_Type, condition: Condition = None, join: JOIN_OPTIONS
     )
 
 
-def _generate_relationship_condition(
-    _: Type["TypedTable"], key: str, field: typing.Union["TypedField[Any]", "Table", Type["TypedTable"]]
-) -> Condition:
+T_Field: typing.TypeAlias = typing.Union["TypedField[Any]", "Table", Type["TypedTable"]]
+
+
+def _generate_relationship_condition(_: Type["TypedTable"], key: str, field: T_Field) -> Condition:
     origin = typing.get_origin(field)
     # else: generic
 
@@ -299,7 +300,7 @@ def _generate_relationship_condition(
 def to_relationship(
     cls: Type["TypedTable"] | type[Any],
     key: str,
-    field: typing.Union["TypedField[Any]", "Table", Type["TypedTable"]],
+    field: T_Field,
 ) -> typing.Optional[Relationship[Any]]:
     """
     Used to automatically create relationship instance for reference fields.
@@ -317,9 +318,14 @@ def to_relationship(
     Also works for list:reference (list[OtherTable]) and TypedField[OtherTable].
     """
     if looks_like(field, TypedField):
+        # typing.get_args works for list[str] but not for TypedField[role] :(
         if args := typing.get_args(field):
+            # TypedField[SomeType] -> SomeType
             field = args[0]
-        else:
+        elif hasattr(field, "_type"):
+            # TypedField(SomeType) -> SomeType
+            field = typing.cast(T_Field, field._type)
+        else:  # pragma: no cover
             # weird
             return None
 
@@ -543,7 +549,7 @@ class TypeDAL(pydal.DAL):  # type: ignore
         ]
 
         # add implicit relationships:
-        # User; list[User]; TypedField[User]; TypedField[list[User]]
+        # User; list[User]; TypedField[User]; TypedField[list[User]]; TypedField(User); TypedField(list[User])
         relationships |= {
             k: new_relationship
             for k in reference_field_keys

--- a/src/typedal/for_web2py.py
+++ b/src/typedal/for_web2py.py
@@ -10,6 +10,8 @@ from .core import TypeDAL, TypedField, TypedTable
 from .fields import TextField
 from .web2py_py4web_shared import AuthUser
 
+DAL = TypeDAL  # export as DAL for compatibility with py4web
+
 
 class AuthGroup(TypedTable):
     """

--- a/src/typedal/mixins.py
+++ b/src/typedal/mixins.py
@@ -11,8 +11,11 @@ import warnings
 from datetime import datetime
 from typing import Any, Optional
 
+from pydal import SQLCustomType
 from slugify import slugify
+from typing_extensions import Self
 
+from . import TypedRows
 from .core import (  # noqa F401 - used by example in docstring
     QueryBuilder,
     T_MetaInstance,
@@ -22,7 +25,7 @@ from .core import (  # noqa F401 - used by example in docstring
     _TypedTable,
 )
 from .fields import DatetimeField, StringField
-from .types import OpRow, Set
+from .types import OpRow, Set, Field
 
 
 class Mixin(_TypedTable):
@@ -79,6 +82,91 @@ def slug_random_suffix(length: int = 8) -> str:
     return base64.urlsafe_b64encode(os.urandom(length)).rstrip(b"=").decode().strip("=")
 
 
+class SearchMixin(Mixin):
+    """
+    Example mixin that provides search() within selected fields per class.
+    """
+    __settings__: typing.TypedDict(  # type: ignore
+        "SearchFieldSettings",
+        {
+            "search_fields": tuple[str, ...],
+        },
+    )  # set via init subclass
+
+    def __init_subclass__(cls, search_fields: tuple[str, ...] = (), **kw: Any) -> None:
+        # append settings:
+        super().__init_subclass__(**kw)
+
+        cls.__settings__ = (getattr(cls, "__settings__", None) or {}) | {
+            "search_fields": search_fields,
+        }
+
+    @classmethod
+    def __search_mixin_daily_seed__(cls):
+        """
+        You can use this as a raw field in .select().
+
+        setseed expects a number between -1 and 1.
+        This function converts the current date to a number in that range.
+        This will break in the year 20000 but who cares.
+        """
+        today = datetime.now()  # dt
+        today = int(today.strftime("%Y%m%d"))  # e.g. 20240201 for 1st of Feb
+        seed = today / 100_000_000
+        return f"setseed({seed})"
+
+    @classmethod
+    def __search_mixin_orderby__(cls, order):
+        extra_fields = []
+        if order == "random":
+            orderby = "<random>"
+            order = (
+                cls.id
+            )  # some field is required for groupby, so might as well use id
+
+            seed = cls.__search_mixin_daily_seed__()
+            extra_fields.append(seed)
+        elif isinstance(order, str):
+            if order.startswith("~"):
+                order = cls[order[1:]]
+                orderby = ~order
+            else:
+                order = cls[order]
+                orderby = order
+        else:
+            orderby = order
+
+        print('orderby', orderby)
+        print('groupby', (cls.gid, order))
+
+    @classmethod
+    def search(cls,
+               search: str = "",
+               limit: int = 0,
+               page: int = 1,
+               order: str | Field | typing.Literal["random"] = None,
+               builder: QueryBuilder[Self] = None,
+               ) -> QueryBuilder[Self]:
+        builder = builder or cls.select()
+
+        if order:
+            cls.__search_mixin_orderby__(order)
+
+        if search:
+            query = cls.id == 0
+            for field in cls.__settings__["search_fields"]:
+
+                if isinstance(cls[field].type, SQLCustomType):
+                    query |= cls[field] == search
+                else:
+                    # todo: there are other cases where .contains is not possible!
+                    query |= cls[field].contains(search)
+
+            builder = builder.where(query)
+
+        return builder
+
+
 class SlugMixin(Mixin):
     """
     (Opinionated) example mixin to add a 'slug' field, which depends on a user-provided other field.
@@ -102,12 +190,15 @@ class SlugMixin(Mixin):
         },
     )  # set via init subclass
 
-    def __init_subclass__(cls, slug_field: str = None, slug_suffix_length: int = 0, **kw: Any) -> None:
+    def __init_subclass__(cls, slug_field: str = None, slug_suffix_length: int = 0, slug_suffix=None,
+                          **kw: Any) -> None:
         """
         Bind 'slug field' option to be used later (on_define).
 
         You can control the length of the random suffix with the `slug_suffix_length` option (0 is no suffix).
         """
+        super().__init_subclass__(**kw)
+
         # unfortunately, PyCharm and mypy do not recognize/autocomplete/typecheck init subclass (keyword) arguments.
         if slug_field is None:
             raise ValueError(
@@ -115,7 +206,7 @@ class SlugMixin(Mixin):
                 "e.g. `class MyClass(TypedTable, SlugMixin, slug_field='title'): ...`"
             )
 
-        if "slug_suffix" in kw:
+        if slug_suffix:
             warnings.warn(
                 "The 'slug_suffix' option is deprecated, use 'slug_suffix_length' instead.",
                 DeprecationWarning,
@@ -123,7 +214,8 @@ class SlugMixin(Mixin):
 
         slug_suffix = slug_suffix_length or kw.get("slug_suffix", 0)
 
-        cls.__settings__ = {
+        # append settings:
+        cls.__settings__ = (getattr(cls, "__settings__", None) or {}) | {
             "slug_field": slug_field,
             "slug_suffix": slug_suffix,
         }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,10 +58,12 @@ def test_load_toml(at_temp_dir):
     base = Path("pyproject.toml")
     base.write_text("# empty")
 
-    assert _load_toml(False) == ("", {})
-    assert _load_toml(None) == (str(base.resolve().absolute()), {})
-    assert _load_toml(str(base)) == ("pyproject.toml", {})
-    assert _load_toml(".") == (str(base.resolve().absolute()), {})
+    with pytest.warns(UserWarning):
+        # it should warn because the toml is empty
+        assert _load_toml(False) == ("", {})
+        assert _load_toml(None) == (str(base.resolve().absolute()), {})
+        assert _load_toml(str(base)) == ("pyproject.toml", {})
+        assert _load_toml(".") == (str(base.resolve().absolute()), {})
 
 
 def test_load_dotenv(at_temp_dir):

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -6,7 +6,7 @@ import pytest
 import uuid
 
 from src.typedal import TypeDAL, TypedTable
-from src.typedal.mixins import SlugMixin, TimestampsMixin, SearchMixin
+from src.typedal.mixins import SlugMixin, TimestampsMixin
 from src.typedal.fields import UUIDField, StringField, TypedField
 
 
@@ -17,18 +17,6 @@ class AllMixins(TypedTable, SlugMixin, TimestampsMixin, slug_field="name"):
 class TableWithMixins(TypedTable, SlugMixin, slug_field="name", slug_suffix_length=1):
     name: str
     number: Optional[int]
-
-
-class ExampleSearchTable(TypedTable,
-                         SlugMixin,
-                         SearchMixin,
-                         slug_field="title",
-                         search_fields=("gid", "title", "description"),
-                         ):
-    gid = UUIDField(default=uuid.uuid4)
-    title: str
-    description: str
-    dont_search: str
 
 
 with pytest.warns(DeprecationWarning):
@@ -106,16 +94,3 @@ def test_reusing(db):
     assert str(TableWithTimestamps.created_at) == "table_with_timestamps.created_at"
     assert str(TableWithTimestamps.unrelated) == "table_with_timestamps.unrelated"
 
-
-def test_search_mixin(db):
-    db.define(ExampleSearchTable)
-
-    row = ExampleSearchTable.insert(
-        title="Example Title",
-        description="Example Description",
-        dont_search="Secret",
-    )
-
-    assert ExampleSearchTable.search("example").count()
-    assert ExampleSearchTable.search(row.gid).count()
-    assert not ExampleSearchTable.search("secret").count()


### PR DESCRIPTION
- Relationships defined as `= TypedField(SomeTable)` and `= TypedField(list[SomeTable])` are now also recognized automatically
- Mixin base class now defines `__settings__` so Mixins can all use it without defining it themselves