### PR TITLE
Improvements to Relationships, updated documentation

### DIFF
--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -32,3 +32,57 @@ for more info about this.
 
 When using py4web, it is recommended to import the py4web-specific TypeDAL, which is a Fixture that handles database
 connections on request (just like the py4web specific DAL class does).
+
+### Simple Queries
+
+For direct SQL access, use `executesql()`:
+
+```python
+rows = db.executesql("SELECT * FROM some_table")
+```
+
+#### Safely Injecting Variables
+
+Use t-strings (Python 3.14+) for automatic SQL escaping:
+
+```python
+name = "Robert'); DROP TABLE Students;--"
+rows = db.executesql(t"SELECT * FROM some_table WHERE name = {name}")
+```
+
+Or use the `placeholders` argument with positional or named parameters:
+
+```python
+# Positional
+rows = db.executesql(
+    "SELECT * FROM some_table WHERE name = %s AND age > %s",
+    placeholders=[name, 18]
+)
+
+# Named
+rows = db.executesql(
+    "SELECT * FROM some_table WHERE name = %(name)s AND age > %(age)s",
+    placeholders={"name": name, "age": 18}
+)
+```
+
+#### Result Formatting
+
+By default, `executesql()` returns rows as tuples. To map results to specific fields, use `fields` (takes Field/TypedField objects) or `colnames` (takes column name strings):
+
+```python
+rows = db.executesql(
+    "SELECT id, name FROM some_table",
+    colnames=["id", "name"]
+)
+
+rows = db.executesql(
+    "SELECT id, name FROM some_table",
+    fields=[some_table.id, some_table.name]  # Requires table definition
+)
+```
+
+You can also use `as_dict` or `as_ordered_dict` to return dictionaries instead of tuples.
+
+Most of the time, you probably don't want to write raw queries. For that, you'll need to define some tables! 
+Head to [page 2](./2_defining_tables.md) to learn how.

--- a/docs/1_getting_started.md
+++ b/docs/1_getting_started.md
@@ -26,12 +26,13 @@ from typedal.for_py4web import TypeDAL
 db = TypeDAL("sqlite:memory")
 ```
 
-TypeDAL accepts the same connection string format and other arguments as `pydal.DAL`. Again,
-see [their documentation](http://www.web2py.com/books/default/chapter/29/06/the-database-abstraction-layer#The-DAL-A-quick-tour)
-for more info about this.
+TypeDAL accepts the same connection string format and other arguments as `pydal.DAL`.
+Again, see
+[their documentation](http://www.web2py.com/books/default/chapter/29/06/the-database-abstraction-layer#The-DAL-A-quick-tour)
+for more info about this. For additional configuration options specific to TypeDAL, see the [7. Advanced Configuration](./7_configuration.md) page.
 
 When using py4web, it is recommended to import the py4web-specific TypeDAL, which is a Fixture that handles database
-connections on request (just like the py4web specific DAL class does).
+connections on request (just like the py4web specific DAL class does). More information about this can be found on [5. py4web](./5_py4web.md)
 
 ### Simple Queries
 
@@ -68,7 +69,8 @@ rows = db.executesql(
 
 #### Result Formatting
 
-By default, `executesql()` returns rows as tuples. To map results to specific fields, use `fields` (takes Field/TypedField objects) or `colnames` (takes column name strings):
+By default, `executesql()` returns rows as tuples. To map results to specific fields, use `fields` (takes
+Field/TypedField objects) or `colnames` (takes column name strings):
 
 ```python
 rows = db.executesql(
@@ -84,5 +86,6 @@ rows = db.executesql(
 
 You can also use `as_dict` or `as_ordered_dict` to return dictionaries instead of tuples.
 
-Most of the time, you probably don't want to write raw queries. For that, you'll need to define some tables! 
-Head to [page 2](./2_defining_tables.md) to learn how.
+Most of the time, you probably don't want to write raw queries. For that, you'll need to define some tables!
+Head to [2. Defining Tables](./2_defining_tables.md) to learn how.
+

--- a/docs/2_defining_tables.md
+++ b/docs/2_defining_tables.md
@@ -102,5 +102,6 @@ def my_after_delete(query: Set):
 
 row.delete_record() # to trigger
 MyTable.where(...).delete() # to trigger
-
 ```
+
+"Now that we have some tables, it's time to actually query them! Let's go to [page 3](./3_building_queries.md) to learn how.

--- a/docs/2_defining_tables.md
+++ b/docs/2_defining_tables.md
@@ -104,4 +104,4 @@ row.delete_record() # to trigger
 MyTable.where(...).delete() # to trigger
 ```
 
-"Now that we have some tables, it's time to actually query them! Let's go to [page 3](./3_building_queries.md) to learn how.
+"Now that we have some tables, it's time to actually query them! Let's go to [3. Building Queries](./3_building_queries.md) to learn how.

--- a/docs/3_building_queries.md
+++ b/docs/3_building_queries.md
@@ -174,3 +174,15 @@ Person.where(id="Old Name").delete()  # via query builder
 person = Person(4)
 person.delete_record()
 ```
+
+```python
+# todo:
+#  - to_sql
+#  - execute
+#  - more .where examples
+#  - .orderby
+#  - seperate page with db.executesql, sql_expression
+#  - nested joins (reference on this page to relationship page, more examples there)
+#  - relationships page: .join(Table.relationship), nested joins, lazy policy (and db config, link to page 8), explicit
+#  - page about config
+```

--- a/docs/3_building_queries.md
+++ b/docs/3_building_queries.md
@@ -153,7 +153,7 @@ This can be overwritten with the `method` keyword argument (left or inner)
 Person.join('articles', method='inner')  # will only yield persons that have related articles
 ```
 
-For more details about relationships and joins, see [page 4](./4_relationships.md).
+For more details about relationships and joins, see [4. Relationships](./4_relationships.md).
 
 ### cache
 
@@ -238,11 +238,4 @@ Person.where(id="Old Name").delete()  # via query builder
 
 person = Person(4)
 person.delete_record()
-```
-
-```python
-# todo:
-#  - nested joins (on page 4)
-#  - relationships page: .join(Table.relationship), nested joins, lazy policy (and db config, link to page 8), `explicit`
-#  - page about config (page 8 with reference on page 1)
 ```

--- a/docs/3_building_queries.md
+++ b/docs/3_building_queries.md
@@ -78,8 +78,8 @@ When passing multiple arguments to a single `.where()`, they will be ORed:
 
 ### select
 
-Here you can enter any number of fields as arguments: database columns by name ('id'), by field reference (table.id) or
-other (e.g. table.ALL).
+Here you can enter any number of fields as arguments: database columns by name ('id'), by field reference (Table.id),
+other (e.g. Table.ALL), or Expression objects.
 
 ```python
 Person.select('id', Person.name, Person.ALL)  # defaults to Person.ALL if select is omitted.
@@ -109,6 +109,36 @@ Person.where(...).orderby(~Person.name, "age")
 `.orderby()` accepts field references (`Table.field` or `"field_name""`), reverse ordering (`~Table.field`), or the
 literal `"<random>"`. Multiple field references can be passed (except when using `<random>`).
 
+#### Raw SQL Expressions
+
+For complex SQL that can't be expressed with field references, use `sql_expression()`:
+
+```python
+# Simple arithmetic
+expr = db.sql_expression("age * 2")
+Person.select(expr)
+
+# Safe parameter injection with t-strings (Python 3.14+)
+min_age = 21
+expr = db.sql_expression(t"age >= {min_age}", output_type="boolean")
+Person.where(expr).select()
+
+# Positional arguments
+expr = db.sql_expression("age > %s AND status = %s", 18, "active", output_type="boolean")
+Person.where(expr).select()
+
+# Named arguments
+expr = db.sql_expression(
+    "EXTRACT(year FROM %(date_col)s) = %(year)s",
+    date_col="created_at",
+    year=2023,
+    output_type="boolean"
+)
+Person.where(expr).select()
+```
+
+Expressions can be used in `where()`, `select()`, `orderby()`, and other query methods.
+
 ### join
 
 Include relationship fields in the result.
@@ -122,6 +152,8 @@ This can be overwritten with the `method` keyword argument (left or inner)
 ```python
 Person.join('articles', method='inner')  # will only yield persons that have related articles
 ```
+
+For more details about relationships and joins, see [page 4](./4_relationships.md).
 
 ### cache
 
@@ -210,8 +242,7 @@ person.delete_record()
 
 ```python
 # todo:
-#  - seperate page with db.executesql, sql_expression
-#  - nested joins (reference on this page to relationship page, more examples there)
-#  - relationships page: .join(Table.relationship), nested joins, lazy policy (and db config, link to page 8), explicit
-#  - page about config
+#  - nested joins (on page 4)
+#  - relationships page: .join(Table.relationship), nested joins, lazy policy (and db config, link to page 8), `explicit`
+#  - page about config (page 8 with reference on page 1)
 ```

--- a/docs/4_relationships.md
+++ b/docs/4_relationships.md
@@ -126,7 +126,7 @@ class Tagged(TypedTable):
 ```
 
 Instead of a `condition`, it is recommended to define an `on`. Using a condition is possible, but could lead to pydal
-generation a `CROSS JOIN` instead of a `LEFT JOIN`, which is bad for performance.
+generating a `CROSS JOIN` instead of a `LEFT JOIN`, which is bad for performance.
 In this example, `Tag` is connected to `Post` and vice versa via the `Tagged` table.
 It is recommended to use the tables received as arguments from the lambda (e.g. `tag.on` instead of `Tag.on` directly),
 since these use aliases under the hood, which prevents conflicts when joining the same table multiple times.

--- a/docs/4_relationships.md
+++ b/docs/4_relationships.md
@@ -20,25 +20,37 @@ class Post(TypedTable):
     author: Author
 
 
-authors_with_roles = Author.join('role').collect()
+authors_with_roles = Author.join('roles').collect()
 posts_with_author = Post.join().collect()  # join can be called without arguments to join all relationships (in this case only 'author')
+post_deep = Post.join("author.roles").collect()  # nested relationship, accessible via post.author.roles
 ```
 
 In this example, the `Post` table contains a reference to the `Author` table. In that case, the `Author` `id` is stored
-in the
-`Post`'s `author` column.
+in the `Post`'s `author` column.
 Furthermore, the `Author` table contains a `list:reference` to `list[Role]`. This means multiple `id`s from the `Role`
-table
-can be stored in the `roles` column of `Author`.
+table can be stored in the `roles` column of `Author`.
 
 For these two cases, a Relationship is set-up automatically, which means `.join()` can work with those.
+
+### Alternative Join Syntax
+
+You can pass the relationship object directly instead of its name as a string:
+
+```python
+posts_with_author = Post.join(Post.author).collect()
+```
+
+This works, but note that `Post.author` is typed as `Relationship[Author]` at the class level, while `row.author` is
+typed as `Author` at the instance level. Some editors may complain about type mismatches when using this syntax (e.g.,
+reporting that `list[Tag]` isn't a `Relationship`). If you encounter type checking issues, use the string syntax
+instead.
 
 ## Other Relationships
 
 To get the reverse relationship, you'll have to tell TypeDAL how the two tables relate to each other (since guessing is
 complex and unreliable).
 
-For example, to set up the reverse relationshp from author to posts:
+For example, to set up the reverse relationship from author to posts:
 
 ```python
 @db.define()
@@ -46,7 +58,6 @@ class Author(TypedTable):
     name: str
 
     posts = relationship(list["Post"], condition=lambda author, post: author.id == post.author, join="left")
-
 ```
 
 Note that `"Post"` is in quotes. This is because the `Post` class is defined later, so a reference to it is not
@@ -62,7 +73,7 @@ class Role(TypedTable):
     authors = relationship(list["Author"], condition=lambda role, author: author.roles.contains(role.id), join="left")
 ```
 
-Here, contains is used since `Author.roles` is a `list:reference`.
+Here, `contains` is used since `Author.roles` is a `list:reference`.
 See [the web2py docs](http://www.web2py.com/books/default/chapter/29/06/the-database-abstraction-layer#list-type-and-contains)
 for more details.
 
@@ -82,8 +93,8 @@ class Sidekick(TypedTable):
     superhero: SuperHero
 ```
 
-In this example, `Relationship["Sidekick"]` is added as an extra type hint, since the reference to the table
-in `relationship("Sidekick", ...)` is a string. This has to be passed as a string, since the Sidekick class is defined
+In this example, `Relationship["Sidekick"]` is added as an extra type hint, since the reference to the table in
+`relationship("Sidekick", ...)` is a string. This has to be passed as a string, since the Sidekick class is defined
 after the superhero class.
 Adding the `Relationship["Sidekick"]` hint is optional, but recommended to improve editor support.
 
@@ -106,6 +117,7 @@ class Post(TypedTable):
         tagged.on(tagged.post == post.id),
         tag.on(tag.id == tagged.tag),
     ])
+
 
 # without unique alias:
 
@@ -130,3 +142,61 @@ generating a `CROSS JOIN` instead of a `LEFT JOIN`, which is bad for performance
 In this example, `Tag` is connected to `Post` and vice versa via the `Tagged` table.
 It is recommended to use the tables received as arguments from the lambda (e.g. `tag.on` instead of `Tag.on` directly),
 since these use aliases under the hood, which prevents conflicts when joining the same table multiple times.
+
+## Lazy Loading and Explicit Relationships
+
+### Lazy Policy
+
+The `lazy` parameter on a relationship controls what happens when you access relationship data without explicitly
+joining it first:
+
+```python
+@db.define()
+class User(TypedTable):
+    name: str
+    posts = relationship(list["Post"], condition=lambda user, post: user.id == post.author, lazy="forbid")
+```
+
+Available policies:
+
+- **`"forbid"`**: Raises an error. Prevents N+1 query problems by making them fail fast.
+- **`"warn"`**: Returns an empty value (empty list or `None`) with a console warning.
+- **`"ignore"`**: Returns an empty value silently.
+- **`"tolerate"`**: Fetches the data but logs a warning about potential performance issues.
+- **`"allow"`**: Fetches the data silently.
+
+If `lazy=None` (the default), the relationship uses the database's default lazy policy. You can set this globally via
+`TypeDAL`'s `lazy_policy` option (see [7. Advanced Configuration](./7_configuration.md) for configuration details),
+which defaults to `"tolerate"`.
+
+### Explicit Relationships
+
+Use `explicit=True` for relationships that are expensive to join or rarely needed:
+
+```python
+@db.define()
+class User(TypedTable):
+    name: str
+    audit_logs = relationship(list["AuditLog"], condition=lambda user, log: user.id == log.user, explicit=True)
+```
+
+When you call `.join()` without arguments, explicit relationships are skipped:
+
+```python
+user = User.join().first()  # user.audit_logs follows the lazy policy (empty/error/warning depending on setting)
+```
+
+To include an explicit relationship, reference it by name:
+
+```python
+user = User.join("audit_logs").first()  # now user.audit_logs is populated
+```
+
+## What's Next?
+
+Depending on your setup:
+
+- **Using py4web or web2py?** → [5. py4web & web2py](./5_py4web.md)
+- **Ready to manage your database?** → [6. Migrations](./6_migrations.md)
+- **Dive deeper into functionality?** → [8.: Mixins](./8_mixins.md)
+

--- a/docs/7_configuration.md
+++ b/docs/7_configuration.md
@@ -1,0 +1,225 @@
+# 7. Configuration
+
+TypeDAL configuration is managed through `pyproject.toml`, `.env` file, environment variables, and `TypeDAL()` kwargs.
+This page documents all available configuration options.
+
+## Basic Setup
+
+Configuration goes under `[tool.typedal]` in your `pyproject.toml`:
+
+```toml
+[tool.typedal]
+database = "sqlite://path/to/database.sqlite"
+folder = "databases"
+caching = true
+pool_size = 0
+lazy_policy = "tolerate"
+# keys may also be written as pool-size, lazy-policy
+```
+
+### Core Options
+
+- **`database`**: Your database URI (required)
+- **`folder`**: Directory for database files (default: `"databases"`). Primarily used by SQLite.
+- **`caching`**: Enable query caching (default: `true`)
+- **`pool_size`**: Connection pool size (default: `1` for sqlite, otherwise `3`). Set to `0` for no pooling.
+- **`connection`**: Which connection config to use in multi-connection setups (default: `"default"`).
+  See "Multiple Connections" below.
+- **`lazy_policy`**: Default policy for implicit relationship loading.
+  Values: `forbid`, `warn`, `ignore`, `tolerate`, `allow` (default: `"tolerate"`).
+  Can be overridden per relationship. See [4. Relationships](./4_relationships.md) for details.
+
+## Migrations
+
+For the minimal configuration required to use migrations, see [6. Migrations](./6_migrations.md).
+Options for generating and running migrations:
+
+```toml
+[tool.typedal]
+input = "path/to/data_model.py"
+output = "path/to/migrations.py"
+dialect = "sqlite"
+magic = true
+function = "define_tables"
+flag_location = "migrations/.flags"
+migrate_table = "typedal_implemented_features"
+create_flag_location = true
+schema = "public"
+migrate = false
+fake_migrate = false
+database_to_restore = "data/backup.sql"
+tables = ["users", "posts"]
+noop = false
+```
+
+### Generating Migrations (pydal2sql)
+
+- **`input`**: Path to your TypeDAL table definitions file
+- **`output`**: Path to the generated migration `.py` fil
+- **`dialect`**: Database type: `sqlite`, `postgres`, `mysql`, etc. (if unclear from database uri)
+- **`magic`**: Insert missing variables to prevent crashes (default: `true`).
+  See [pydal2sql docs](https://github.com/robinvandernoord/pydal2sql#configuration).
+- **`function`**: Function name containing your `db.define()` calls (default: `"define_tables"`)
+- **`tables`**: Specific tables to generate migrations for (optional; usually set via CLI instead)
+- **`noop`**: Don't write to output (usually set via CLI)
+
+### Running Migrations (edwh-migrate)
+
+- **`output`**: Path to the migration `.py` file containing your migrations
+- **`flag_location`**: Directory where migration flags are stored
+- **`create_flag_location`**: Auto-create flag location if missing (default: `true`)
+- **`migrate_table`**: Table name tracking executed migrations (default: `"typedal_implemented_features"`)
+- **`schema`**: Database schema to use (default: `"public"`, mainly for PostgreSQL)
+- **`database_to_restore`**: Optional SQL file to restore before running migrations
+
+For advanced options like `migrate_cat_command`, `schema_version`, and `redis_host`, see
+the [edwh-migrate documentation](https://github.com/educationwarehouse/migrate#documentation).
+
+### Migration Behavior
+
+- **`migrate`**: Enable pydal's automatic migration behavior (default: `true`). Set to `false` in production to use
+  manual migrations.
+- **`fake_migrate`**: Mark migrations as executed without running them (default: `false`). Useful for initial setup or
+  recovery.
+
+For full details on pydal2sql options, see
+the [pydal2sql configuration documentation](https://github.com/robinvandernoord/pydal2sql#configuration).
+
+## Multiple Connections
+
+Configure multiple database connections and switch between them:
+
+```toml
+[tool.typedal]
+default = "development"
+
+[tool.typedal.development]
+database = "sqlite://"
+dialect = "sqlite"
+migrate = true
+
+[tool.typedal.production]
+dialect = "postgres"
+migrate = false
+```
+
+```env
+TYPEDAL_CONNECTION="production"
+TYPEDAL_DATABASE="psql://user:password@host:5432/database"
+```
+
+- Set `default` to the connection used when `TYPEDAL_CONNECTION` is not set
+- Each connection can have its own `[tool.typedal.connection_name]` section
+- Environment variables override config values; use `TYPEDAL_CONNECTION` to switch active connections
+- Secrets (like database URIs) should go in `.env` prefixed with `TYPEDAL_`
+
+## Configuration Priority
+
+TypeDAL loads configuration in this order (highest priority last):
+
+1. **`pyproject.toml`** — Base configuration
+2. **`.env` file** — Environment-specific overrides
+3. **Environment variables** — System env vars with `TYPEDAL_` prefix (override `.env`)
+4. **`TypeDAL()` kwargs** — Runtime arguments passed to the constructor
+
+Example with all layers:
+
+```toml
+# pyproject.toml
+[tool.typedal]
+database = "sqlite://"
+pool_size = 5
+```
+
+```env
+# .env
+TYPEDAL_DATABASE="psql://localhost/dev"
+TYPEDAL_POOL_SIZE=10
+```
+
+```bash
+# shell
+export TYPEDAL_POOL_SIZE=20
+```
+
+```python
+# code (highest priority)
+db = TypeDAL(database="psql://prod/db")
+```
+
+The resulting config uses: `database="psql://prod/db"` and `pool_size=20` (from the environment variable).
+
+## Environment Variables & Variable Interpolation
+
+Override any config value using environment variables prefixed with `TYPEDAL_`:
+
+```env
+TYPEDAL_DATABASE="psql://..."
+TYPEDAL_FOLDER="custom_folder"
+TYPEDAL_POOL_SIZE=10
+TYPEDAL_CACHING=false
+TYPEDAL_LAZY_POLICY="forbid"
+```
+
+You can also use variable interpolation in your config to reference environment variables or `.env` values:
+
+```toml
+# pyproject.toml
+[tool.typedal]
+database = "psql://user:${DB_PASSWORD:defaultpass}@host:5432/database"
+```
+
+```env
+# .env
+DB_PASSWORD="secretpassword"
+```
+
+Use `${VAR:default}` syntax. If `VAR` is not set, `default` is used.
+
+## TypeDAL() Constructor Options
+
+Pass configuration directly when instantiating TypeDAL:
+
+```python
+from typedal import TypeDAL
+
+db = TypeDAL(
+    "sqlite://...",
+    # *other pydal configuration
+    # optional extra typedal settings:
+    use_pyproject=True,
+    use_env=True,
+    connection="production",
+    lazy_policy="forbid",
+    enable_typedal_caching=True,
+)
+```
+
+- **`use_pyproject`**: Load config from `pyproject.toml` (default: `True`). Set to a string path to use a custom file.
+- **`use_env`**: Load config from `.env` and environment variables (default: `True`). Set to a string path to use a
+  custom `.env` file, or `False` to disable.
+- **`connection`**: Which connection to use in multi-connection setups
+- **`lazy_policy`**: Override default lazy loading policy
+- **`enable_typedal_caching`**: Override caching setting
+- **`config`**: Pass a pre-built `TypeDALConfig` object directly
+
+## Setup & Inspection
+
+Generate a config interactively:
+
+```bash
+typedal setup        # full setup wizard
+typedal setup --minimal  # skip non-essential prompts
+```
+
+View your current active configuration:
+
+```bash
+typedal --show-config
+```
+
+---
+
+You've conquered the boring bits. 
+Ready for something more interesting? 
+Head to [8. Mixins](./8_mixins.md) to create powerful, reusable logic with mixins.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,10 @@
 # 0. Table of Contents
 
-1. [Getting Started](1_getting_started.md)
-2. [Defining Tables](2_defining_tables.md)
-3. [Building Queries](3_building_queries.md)
-4. [Relationships](4_relationships.md)
+1. [Getting Started](./1_getting_started.md)
+2. [Defining Tables](./2_defining_tables.md)
+3. [Building Queries](./3_building_queries.md)
+4. [Relationships](./4_relationships.md)
 5. [py4web & web2py](./5_py4web.md)
 6. [Migrations](./6_migrations.md)
-7. [Mixins](./7_mixins.md)
+7. [Advanced Configuration](./7_configuration.md)
+8. [Mixins](./8_mixins.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,8 @@ nav:
   - 4. Relationships: 4_relationships.md
   - 5. py4web: 5_py4web.md
   - 6. Migrations: 6_migrations.md
-  - 7. Mixins: 7_mixins.md
+  - 7. Configuration: 7_configuration.md
+  - 8. Mixins: 8_mixins.md
 extra:
   version:
     default: stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,3 +236,5 @@ pythonpath = [
 ]
 
 [tool.typedal]
+# e.g.
+# lazy-policy = "forbid"

--- a/src/typedal/caching.py
+++ b/src/typedal/caching.py
@@ -260,7 +260,7 @@ def _load_from_cache(key: str, db: "TypeDAL") -> t.Any | None:
 
     inst.db = db
     inst.model = db._class_map[inst.model]
-    inst.model._setup_instance_methods(inst.model)  # type: ignore
+    inst.model._setup_instance_methods(inst.model)
     return inst
 
 

--- a/src/typedal/cli.py
+++ b/src/typedal/cli.py
@@ -392,7 +392,8 @@ def fake_migrations(
 
     previously_migrated = (
         db(
-            db.ewh_implemented_features.name.belongs(to_fake) & (db.ewh_implemented_features.installed == True)  # noqa E712
+            db.ewh_implemented_features.name.belongs(to_fake)
+            & (db.ewh_implemented_features.installed == True)  # noqa E712
         )
         .select(db.ewh_implemented_features.name)
         .column("name")

--- a/src/typedal/config.py
+++ b/src/typedal/config.py
@@ -2,6 +2,8 @@
 TypeDAL can be configured by a combination of pyproject.toml (static), env (dynamic) and code (programmic).
 """
 
+from __future__ import annotations
+
 import os
 import re
 import typing as t
@@ -20,6 +22,8 @@ if t.TYPE_CHECKING:
     from edwh_migrate import Config as MigrateConfig
     from pydal2sql.typer_support import Config as P2SConfig
 
+    from .relationships import LazyPolicy
+
 
 class TypeDALConfig(TypedConfig):
     """
@@ -34,6 +38,7 @@ class TypeDALConfig(TypedConfig):
     pool_size: int = 0
     pyproject: str
     connection: str = "default"
+    lazy_policy: "LazyPolicy" = "tolerate"
 
     # pydal2sql:
     input: str = ""

--- a/src/typedal/config.py
+++ b/src/typedal/config.py
@@ -2,8 +2,6 @@
 TypeDAL can be configured by a combination of pyproject.toml (static), env (dynamic) and code (programmic).
 """
 
-from __future__ import annotations
-
 import os
 import re
 import typing as t
@@ -22,7 +20,7 @@ if t.TYPE_CHECKING:
     from edwh_migrate import Config as MigrateConfig
     from pydal2sql.typer_support import Config as P2SConfig
 
-    from .relationships import LazyPolicy
+LazyPolicy = t.Literal["forbid", "warn", "ignore", "tolerate", "allow"]
 
 
 class TypeDALConfig(TypedConfig):
@@ -38,7 +36,7 @@ class TypeDALConfig(TypedConfig):
     pool_size: int = 0
     pyproject: str
     connection: str = "default"
-    lazy_policy: "LazyPolicy" = "tolerate"
+    lazy_policy: LazyPolicy = "tolerate"
 
     # pydal2sql:
     input: str = ""

--- a/src/typedal/core.py
+++ b/src/typedal/core.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 import pydal
 
-from .config import TypeDALConfig, load_config
+from .config import LazyPolicy, TypeDALConfig, load_config
 from .helpers import (
     SYSTEM_SUPPORTS_TEMPLATES,
     default_representer,
@@ -31,7 +31,6 @@ except ImportError:  # pragma: no cover
 
 if t.TYPE_CHECKING:
     from .fields import TypedField
-    from .relationships import LazyPolicy
     from .types import AnyDict, Expression, T_Query, Table
 
 

--- a/src/typedal/core.py
+++ b/src/typedal/core.py
@@ -31,6 +31,7 @@ except ImportError:  # pragma: no cover
 
 if t.TYPE_CHECKING:
     from .fields import TypedField
+    from .relationships import LazyPolicy
     from .types import AnyDict, Expression, T_Query, Table
 
 
@@ -138,7 +139,7 @@ def resolve_annotation(ftype: str) -> type:  # pragma: no cover
         return resolve_annotation_314(ftype)
 
 
-class TypeDAL(pydal.DAL):  # type: ignore
+class TypeDAL(pydal.DAL):
     """
     Drop-in replacement for pyDAL with layer to convert class-based table definitions to classical pydal define_tables.
     """
@@ -176,6 +177,7 @@ class TypeDAL(pydal.DAL):  # type: ignore
         use_env: bool | str = True,
         connection: Optional[str] = None,
         config: Optional[TypeDALConfig] = None,
+        lazy_policy: LazyPolicy | None = None,
     ) -> None:
         """
         Adds some internal tables after calling pydal's default init.
@@ -191,6 +193,7 @@ class TypeDAL(pydal.DAL):  # type: ignore
             fake_migrate=fake_migrate,
             caching=enable_typedal_caching,
             pool_size=pool_size,
+            lazy_policy=lazy_policy,
         )
 
         self._config = config

--- a/src/typedal/define.py
+++ b/src/typedal/define.py
@@ -65,7 +65,7 @@ class TableDefinitionBuilder:
             k: instanciate(v, True) for k, v in annotations.items() if is_typed_field(v)
         }
 
-        relationships: dict[str, type[Relationship[t.Any]]] = filter_out(annotations, Relationship)
+        relationships: dict[str, type[Relationship[t.Any]]] = filter_out(annotations, Relationship)  # type: ignore
         fields = {fname: self.to_field(fname, ftype) for fname, ftype in annotations.items()}
 
         other_kwargs = kwargs | {
@@ -77,7 +77,7 @@ class TableDefinitionBuilder:
             setattr(cls, key, clone)
             typedfields[key] = clone
 
-        relationships = filter_out(full_dict, Relationship) | relationships | filter_out(other_kwargs, Relationship)
+        relationships = filter_out(full_dict, Relationship) | relationships | filter_out(other_kwargs, Relationship)  # type: ignore
 
         reference_field_keys = [
             k for k, v in fields.items() if str(v.type).split(" ")[0] in ("list:reference", "reference")
@@ -157,7 +157,7 @@ class TableDefinitionBuilder:
         elif origin_is_subclass(ftype, TypedField):
             # TypedField[int]
             return self.annotation_to_pydal_fieldtype(t.get_args(ftype)[0], mut_kw)
-        elif isinstance(ftype, types.GenericAlias) and t.get_origin(ftype) in (list, TypedField):  # type: ignore
+        elif isinstance(ftype, types.GenericAlias) and t.get_origin(ftype) in (list, TypedField):
             # list[str] -> str -> string -> list:string
             _child_type = t.get_args(ftype)[0]
             _child_type = self.annotation_to_pydal_fieldtype(_child_type, mut_kw)

--- a/src/typedal/for_py4web.py
+++ b/src/typedal/for_py4web.py
@@ -14,7 +14,7 @@ from .types import AnyDict
 from .web2py_py4web_shared import AuthUser
 
 
-class Fixture(_Fixture):  # type: ignore
+class Fixture(_Fixture):
     """
     Make mypy happy.
     """

--- a/src/typedal/helpers.py
+++ b/src/typedal/helpers.py
@@ -189,7 +189,7 @@ def looks_like(v: t.Any, _type: type[t.Any]) -> bool:
     return isinstance(v, _type) or (isinstance(v, type) and issubclass(v, _type)) or origin_is_subclass(v, _type)
 
 
-def filter_out(mut_dict: dict[K, V], _type: type[T]) -> dict[K, type[T]]:
+def filter_out(mut_dict: dict[K, V], _type: type[T]) -> dict[K, T]:
     """
     Split a dictionary into things matching _type and the rest.
 

--- a/src/typedal/relationships.py
+++ b/src/typedal/relationships.py
@@ -119,7 +119,7 @@ class Relationship(t.Generic[To_Type]):
         return f"<Relationship{join}{lazy_str} {src_code}>"
 
     def __set_name__(self, owner: t.Type["TypedTable"], name: str) -> None:
-        """Called automatically when assigned to a class attribute"""
+        """Called automatically when assigned to a class attribute."""
         self.name = name
 
     def get_table(self, db: "TypeDAL") -> t.Type["TypedTable"]:
@@ -150,8 +150,9 @@ class Relationship(t.Generic[To_Type]):
     @property
     def lazy(self) -> LazyPolicy:
         """
-        Gets the lazy policy configured in the current context. The method first checks
-        for a customized lazy policy for this relationship.
+        Gets the lazy policy configured in the current context.
+
+        The method first checks for a customized lazy policy for this relationship.
         If not found, it attempts to retrieve the lazy policy from the database.
         If neither option is available, it returns a conservative fallback value.
 

--- a/src/typedal/relationships.py
+++ b/src/typedal/relationships.py
@@ -16,6 +16,11 @@ from .types import Condition, OnQuery, T_Field
 
 To_Type = t.TypeVar("To_Type")
 
+LazyPolicy = t.Literal["forbid", "warn", "ignore", "tolerate", "allow"]
+
+
+# default lazy policy is defined at the TypeDAL() instance settings level
+
 
 class Relationship(t.Generic[To_Type]):
     """
@@ -23,13 +28,16 @@ class Relationship(t.Generic[To_Type]):
     """
 
     _type: t.Type[To_Type]
-    table: t.Type["TypedTable"] | type | str
+    table: t.Type["TypedTable"] | type | str  # use get_table() to resolve later on
     condition: Condition
     condition_and: Condition
     on: OnQuery
     multiple: bool
     join: JOIN_OPTIONS
+    _lazy: LazyPolicy | None
     nested: dict[str, t.Self]
+    explicit: bool
+    name: str | None = None  # set by __set_name__
 
     def __init__(
         self,
@@ -39,19 +47,21 @@ class Relationship(t.Generic[To_Type]):
         on: OnQuery = None,
         condition_and: Condition = None,
         nested: dict[str, t.Self] = None,
+        lazy: LazyPolicy | None = None,
+        explicit: bool = False,
     ):
         """
         Should not be called directly, use relationship() instead!
         """
         if condition and on:
-            warnings.warn(f"Relation | Both specified! {condition=} {on=} {_type=}")
-            raise ValueError("Please specify either a condition or an 'on' statement for this relationship!")
+            raise self._error_duplicate_condition(condition, on)
 
         self._type = _type
         self.condition = condition
         self.join = "left" if on else join  # .on is always left join!
         self.on = on
         self.condition_and = condition_and
+        self._lazy = lazy
 
         if args := t.get_args(_type):
             self.table = unwrap_type(args[0])
@@ -63,20 +73,33 @@ class Relationship(t.Generic[To_Type]):
         if isinstance(self.table, str):
             self.table = TypeDAL.to_snake(self.table)
 
+        self.explicit = explicit
         self.nested = nested or {}
 
     def clone(self, **update: t.Any) -> "Relationship[To_Type]":
         """
         Create a copy of the relationship, possibly updated.
         """
+        condition = update.get("condition")
+        on = update.get("on")
+
+        if on and condition:  # pragma: no cover
+            raise self._error_duplicate_condition(condition, on)
+
         return self.__class__(
             update.get("_type") or self._type,
-            update.get("condition") or self.condition,
+            None if on else (condition or self.condition),
             update.get("join") or self.join,
-            update.get("on") or self.on,
+            None if condition else (on or self.on),
             update.get("condition_and") or self.condition_and,
             (self.nested | extra) if (extra := update.get("nested")) else self.nested,  # type: ignore
+            update.get("lazy") or self._lazy,
         )
+
+    @staticmethod
+    def _error_duplicate_condition(condition: Condition, on: OnQuery) -> t.Never:
+        warnings.warn(f"Relation | Both specified! {condition=} {on=}")
+        raise ValueError("Please specify either a condition or an 'on' statement for this relationship!")
 
     def __repr__(self) -> str:
         """
@@ -93,7 +116,12 @@ class Relationship(t.Generic[To_Type]):
             src_code = f"to {cls_name} (missing condition)"
 
         join = f":{self.join}" if self.join else ""
-        return f"<Relationship{join} {src_code}>"
+        lazy_str = f" lazy={self.lazy}" if self.lazy != "warn" else ""
+        return f"<Relationship{join}{lazy_str} {src_code}>"
+
+    def __set_name__(self, owner: t.Type["TypedTable"], name: str) -> None:
+        """Called automatically when assigned to a class attribute"""
+        self.name = name
 
     def get_table(self, db: "TypeDAL") -> t.Type["TypedTable"]:
         """
@@ -110,6 +138,35 @@ class Relationship(t.Generic[To_Type]):
             return t.cast(t.Type["TypedTable"], db[table])  # eh close enough!
 
         return table
+
+    def get_db(self) -> TypeDAL | None:
+        """
+        Retrieves the database instance associated with the table.
+
+        Returns:
+            TypeDAL | None: The database instance if it exists, or None otherwise.
+        """
+        return getattr(self.table, "_db", None)
+
+    @property
+    def lazy(self) -> LazyPolicy:
+        """
+        Gets the lazy policy configured in the current context. The method first checks
+        for a customized lazy policy for this relationship.
+        If not found, it attempts to retrieve the lazy policy from the database.
+        If neither option is available, it returns a conservative fallback value.
+
+        Returns:
+            LazyPolicy or str: The configured lazy policy or a fallback value.
+        """
+        if customized := self._lazy:
+            return customized
+
+        if db := self.get_db():
+            return db._config.lazy_policy
+
+        # conservative fallback:
+        return "warn"
 
     def get_table_name(self) -> str:
         """
@@ -129,35 +186,104 @@ class Relationship(t.Generic[To_Type]):
 
         return str(table)
 
-    def __get__(self, instance: t.Any, owner: t.Any) -> "t.Optional[list[t.Any]] | Relationship[To_Type]":
+    def __get__(
+        self,
+        instance: "TypedTable",
+        owner: t.Type["TypedTable"],
+    ) -> "t.Optional[list[t.Any]] | Relationship[To_Type]":
         """
         Relationship is a descriptor class, which can be returned from a class but not an instance.
 
         For an instance, using .join() will replace the Relationship with the actual data.
-        If you forgot to join, a warning will be shown and empty data will be returned.
+        Behavior when accessed without joining depends on the lazy policy.
         """
         if not instance:
             # relationship queried on class, that's allowed
             return self
 
-        warnings.warn(
-            "Trying to get data from a relationship object! Did you forget to join it?",
-            category=RuntimeWarning,
-        )
-        if self.multiple:
-            return []
-        else:
-            return None
+        # instance: TypedTable instance
+        # owner: TypedTable class
+
+        if not self.name:  # pragma: no cover
+            raise ValueError("Relationship does not seem to be connected to a table field.")
+
+        # Handle different lazy policies
+        if self.lazy == "forbid":  # pragma: no cover
+            raise AttributeError(
+                f"Accessing relationship '{self.name}' without joining is forbidden. "
+                f"Use .join('{self.name}') in your query or set lazy='allow' if this is intentional.",
+            )
+
+        fallback_value: t.Optional[list[t.Any]] = [] if self.multiple else None
+
+        if self.lazy == "ignore":  # pragma: no cover
+            # Return empty silently
+            return fallback_value
+
+        if self.lazy == "warn":
+            # Warn and return empty
+            warnings.warn(
+                f"Trying to access relationship '{self.name}' without joining. "
+                f"Did you forget to use .join('{self.name}')? Returning empty value.",
+                category=RuntimeWarning,
+            )
+            return fallback_value
+
+        # For "tolerate" and "allow", we fetch the data
+        try:
+            resolved_table = self.get_table(instance._db)
+
+            builder = owner.where(id=instance.id).join(self.name)
+            if issubclass(resolved_table, TypedTable) or isinstance(resolved_table, pydal.objects.Table):
+                # is a table so we can select ALL and ignore non-required fields of parent row:
+                builder = builder.select(owner.id, resolved_table.ALL)
+
+            if self.lazy == "tolerate":
+                warnings.warn(
+                    f"Lazy loading relationship '{self.name}'. "
+                    "This performs an extra database query. "
+                    f"Consider using .join('{self.name}') for better performance.",
+                    category=RuntimeWarning,
+                )
+
+            return builder.first()[self.name]  # type: ignore
+        except Exception as e:  # pragma: no cover
+            warnings.warn(
+                f"Failed to lazy load relationship '{self.name}': {e}",
+                category=RuntimeWarning,
+                source=e,
+            )
+
+            return fallback_value
 
 
 def relationship(
-    _type: t.Type[To_Type],
+    _type: t.Type[To_Type] | str,
     condition: Condition = None,
     join: JOIN_OPTIONS = None,
     on: OnQuery = None,
+    lazy: LazyPolicy | None = None,
+    explicit: bool = False,
 ) -> To_Type:
     """
     Define a relationship to another table, when its id is not stored in the current table.
+
+    Args:
+        _type: The type of the related table. Use list[Type] for one-to-many relationships.
+        condition: Lambda function defining the join condition between tables.
+                   Example: lambda self, post: self.id == post.author
+        join: Join strategy ('left', 'inner', etc.). Defaults to 'left' when using 'on'.
+        on: Alternative to condition for complex queries with pivot tables.
+            Allows specifying multiple join conditions to avoid cross joins.
+        lazy: Controls behavior when accessing relationship data without explicitly joining:
+            - "forbid": Raise an error (strictest, prevents N+1 queries)
+            - "warn": Return empty value with warning
+            - "ignore": Return empty value silently
+            - "tolerate": Fetch data with warning (convenient but warns about performance)
+            - "allow": Fetch data silently (most permissive, use only for known cheap queries)
+        explicit: If True, this relationship is only joined when explicitly requested
+                  (e.g. User.join("tags")). Bare User.join() calls will skip it.
+                  Useful for expensive or rarely-needed relationships. Defaults to False.
 
     Example:
         class User(TypedTable):
@@ -174,7 +300,7 @@ def relationship(
     Here, Post stores the User ID, but `relationship(list["Post"])` still allows you to get the user's posts.
     In this case, the join strategy is set to LEFT so users without posts are also still selected.
 
-    For complex queries with a pivot table, a `on` can be set insteaad of `condition`:
+    For complex queries with a pivot table, 'on' can be set instead of 'condition':
         class User(TypedTable):
         ...
 
@@ -190,7 +316,7 @@ def relationship(
         # so for ease of use, just cast to the refered type for now!
         # e.g. x = relationship(Author) -> x: Author
         To_Type,
-        Relationship(_type, condition, join, on),
+        Relationship(_type, condition, join, on, lazy=lazy, explicit=explicit),  # type: ignore
     )
 
 

--- a/src/typedal/relationships.py
+++ b/src/typedal/relationships.py
@@ -8,6 +8,7 @@ import warnings
 
 import pydal.objects
 
+from .config import LazyPolicy
 from .constants import JOIN_OPTIONS
 from .core import TypeDAL
 from .fields import TypedField
@@ -15,8 +16,6 @@ from .helpers import extract_type_optional, looks_like, unwrap_type
 from .types import Condition, OnQuery, T_Field
 
 To_Type = t.TypeVar("To_Type")
-
-LazyPolicy = t.Literal["forbid", "warn", "ignore", "tolerate", "allow"]
 
 
 # default lazy policy is defined at the TypeDAL() instance settings level

--- a/src/typedal/rows.py
+++ b/src/typedal/rows.py
@@ -491,7 +491,7 @@ class PaginatedRows(TypedRows[T_MetaInstance]):
         return {"data": super().as_dict(), "pagination": self.pagination}
 
 
-class TypedSet(pydal.objects.Set):  # type: ignore # pragma: no cover
+class TypedSet(pydal.objects.Set):  # pragma: no cover
     """
     Used to make pydal Set more typed.
 

--- a/src/typedal/tables.py
+++ b/src/typedal/tables.py
@@ -358,7 +358,7 @@ class TableMeta(type):
 
     def join(
         self: t.Type[T_MetaInstance],
-        *fields: str | t.Type["TypedTable"],
+        *fields: str | t.Type[TypedTable] | Relationship[t.Any],
         method: JOIN_OPTIONS = None,
         on: OnQuery | list[Expression] | Expression = None,
         condition: Condition = None,
@@ -777,6 +777,15 @@ class TypedTable(_TypedTable, metaclass=TableMeta):
             return value
 
         raise AttributeError(item)
+
+    def __eq__(self, other: t.Any) -> bool:
+        """
+        Compare equal classes via their _row, since the other data is irrelevant for equality.
+        """
+        if type(self) is not type(other):
+            return False
+
+        return self._row == other._row  # type: ignore
 
     def keys(self) -> list[str]:
         """

--- a/src/typedal/types.py
+++ b/src/typedal/types.py
@@ -88,15 +88,15 @@ class FileSystemLike(t.Protocol):  # pragma: no cover
 # ---------------------------------------------------------------------------
 
 
-class Query(_Query):  # type: ignore
+class Query(_Query):
     """Pydal Query object. Makes mypy happy."""
 
 
-class Expression(_Expression):  # type: ignore
+class Expression(_Expression):
     """Pydal Expression object. Make mypy happy."""
 
 
-class Set(_Set):  # type: ignore
+class Set(_Set):
     """Pydal Set object. Make mypy happy."""
 
 
@@ -117,19 +117,19 @@ if t.TYPE_CHECKING:
 
 else:
 
-    class OpRow(_OpRow):  # type: ignore
+    class OpRow(_OpRow):
         """Runtime OpRow, using pydal's version."""
 
 
-class Reference(_Reference):  # type: ignore
+class Reference(_Reference):
     """Pydal Reference object. Make mypy happy."""
 
 
-class Field(_Field):  # type: ignore
+class Field(_Field):
     """Pydal Field object. Make mypy happy."""
 
 
-class Rows(_Rows):  # type: ignore
+class Rows(_Rows):
     """Pydal Rows object. Make mypy happy."""
 
     def column(self, column: t.Any = None) -> list[t.Any]:
@@ -146,11 +146,11 @@ class Row(_Row):
     """Pydal Row object. Make mypy happy."""
 
 
-class Validator(_Validator):  # type: ignore
+class Validator(_Validator):
     """Pydal Validator object. Make mypy happy."""
 
 
-class Table(_Table, TableProtocol):  # type: ignore
+class Table(_Table, TableProtocol):
     """Table with protocol support. Make mypy happy."""
 
 

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -375,7 +375,6 @@ def test_get_relationship_after_initial():
     article1 = Article.where(title="Article 1").first_or_fail()
     article2 = Article.where(title="Article 1").join(Article.tags).first_or_fail()
 
-    # todo: .tags is defined as non-eager (? naming)
     with pytest.warns(RuntimeWarning):
         assert article1.tags == []
 

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -1,6 +1,9 @@
+import contextlib
+import json
 import time
 import types
 import typing
+import warnings
 from uuid import uuid4
 
 import pytest
@@ -13,6 +16,7 @@ from src.typedal.caching import (
     clear_expired,
     remove_cache,
 )
+from src.typedal.serializers import as_json
 
 db = TypeDAL("sqlite:memory")
 
@@ -28,8 +32,22 @@ class TaggableMixin:
             tagged.on(tagged.entity == entity.gid),
             tag.on((tagged.tag == tag.id)),
         ],
+        lazy="warn",  # default behavior
     )
-    # tags = relationship(list["Tag"], tagged)
+
+    tags_tolerate = relationship(
+        list["Tag"],
+        # lambda self, _: (Tagged.entity == self.gid) & (Tagged.tag == Tag.id)
+        # doing an .on with and & inside can lead to a cross join,
+        # for relationships with pivot tables a manual on query with aliases is prefered:
+        on=lambda entity, tag: [
+            tagged := Tagged.unique_alias(),
+            tagged.on(tagged.entity == entity.gid),
+            tag.on((tagged.tag == tag.id)),
+        ],
+        lazy="tolerate",  # load but with warning
+        explicit=True,  # only load when requested
+    )
 
 
 @db.define()
@@ -84,7 +102,8 @@ class Tagged(TypedTable):  # pivot table
 
 
 @db.define()
-class Empty(TypedTable): ...
+class Empty(TypedTable):
+    ...
 
 
 def _setup_data():
@@ -184,7 +203,7 @@ def test_typedal_way():
         Empty.first_or_fail()
 
     # user through article: 1 - many
-    all_articles = Article.join().collect().as_dict()
+    all_articles = Article.join("author", "secondary_author", "final_editor", "tags").collect().as_dict()
 
     assert all_articles[3]["final_editor"]["name"] == "Editor 1"
     assert all_articles[4]["secondary_author"]["name"] == "Editor 1"
@@ -208,7 +227,9 @@ def test_typedal_way():
     with pytest.warns(RuntimeWarning):
         assert article2.tags == []
 
-    articles1 = Article.where(title="Article 1").join().first_or_fail()
+    articles1 = (
+        Article.where(title="Article 1").join("author", "secondary_author", "final_editor", "tags").first_or_fail()
+    )
 
     assert articles1.final_editor.name == "Editor 1"
 
@@ -286,14 +307,15 @@ def test_typedal_way():
 
     # from role to users: BelongsToMany via list:reference
 
-    role_writer = Role.where(Role.name == "writer").join().first_or_fail()
+    role_writer = Role.where(Role.name == "writer").join("users", "tags").first_or_fail()
 
     assert len(role_writer.users) == 2
 
-    author1 = User.where(id=4).join().first()
+    author1 = User.where(id=4).join("articles").first()
 
     assert (
-        len(author1.as_dict()["articles"]) == len(author1.__dict__["articles"]) == len(dict(author1)["articles"]) == 2
+            len(author1.as_dict()["articles"]) == len(author1.__dict__["articles"]) == len(
+        dict(author1)["articles"]) == 2
     )
 
 
@@ -336,6 +358,36 @@ def test_reprs():
     ]
 
     assert "AND" in repr(relation) and "Hank" in repr(relation)
+
+
+@contextlib.contextmanager
+def no_warnings():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        yield
+        if caught:
+            raise AssertionError(f"Unexpected warnings: {[w.message for w in caught]}")
+
+
+def test_get_relationship_after_initial():
+    _setup_data()
+
+    article1 = Article.where(title="Article 1").first_or_fail()
+    article2 = Article.where(title="Article 1").join(Article.tags).first_or_fail()
+
+    # todo: .tags is defined as non-eager (? naming)
+    with pytest.warns(RuntimeWarning):
+        assert article1.tags == []
+
+    with pytest.warns(RuntimeWarning):
+        # tolerate includes warning
+        tags_tolerate = article1.tags_tolerate
+        assert tags_tolerate
+
+    with no_warnings():
+        # expect no warnings
+        assert as_json.encode(tags_tolerate) == as_json.encode(article2.tags)
+        assert tags_tolerate == article2.tags
 
 
 @db.define()
@@ -401,6 +453,8 @@ def test_join_with_different_condition():
 
 
 def test_caching():
+    _setup_data()
+
     uncached = User.join().collect_or_fail()
     cached = User.cache().join().collect_or_fail()  # not actually cached yet!
     cached_user_only = User.join().cache(User.id).collect_or_fail()  # idem
@@ -430,12 +484,12 @@ def test_caching():
     cached_user_only2 = User.join().cache(User.id).collect_or_fail()
 
     assert (
-        len(uncached2)
-        == len(uncached)
-        == len(cached2)
-        == len(cached)
-        == len(cached_user_only2)
-        == len(cached_user_only)
+            len(uncached2)
+            == len(uncached)
+            == len(cached2)
+            == len(cached)
+            == len(cached_user_only2)
+            == len(cached_user_only)
     )
 
     assert uncached.as_json() == uncached2.as_json() == cached.as_json() == cached2.as_json()
@@ -443,9 +497,9 @@ def test_caching():
     assert cached.first().gid == cached2.first().gid
 
     assert (
-        [_.name for _ in uncached2.first().roles]
-        == [_.name for _ in cached.first().roles]
-        == [_.name for _ in cached2.first().roles]
+            [_.name for _ in uncached2.first().roles]
+            == [_.name for _ in cached.first().roles]
+            == [_.name for _ in cached2.first().roles]
     )
 
     assert not uncached2.metadata.get("cache", {}).get("enabled")
@@ -583,9 +637,30 @@ def test_caching_dependencies():
 
 def test_illegal():
     with pytest.raises(ValueError), pytest.warns(UserWarning):
-
         class HasRelationship:
             something = relationship("...", condition=lambda: 1, on=lambda: 2)
+
+    with pytest.raises(ValueError), pytest.warns(UserWarning):
+        Tag.join(Tag.articles, condition=lambda: 1, on=lambda: 2)
+
+def test_join_relationship_custom_on():
+    _setup_data()
+
+    rows1 = Tag.join(Tag.articles,
+                     condition=lambda tag, article: (Tagged.tag == tag.id) & (article.gid == Tagged.entity) & (article.author == 3),
+                     method="inner",
+                     )
+
+    rows2 = Tag.join(Tag.articles,
+                     on=lambda tag, article: [
+                         tagged := Tagged.unique_alias(),
+                         (tagged.tag == tag.id) & (article.gid == tagged.entity) & (article.author == 3)
+                     ],
+                     method="inner",
+                     )
+
+    assert all([row.articles for row in rows1])
+    assert all([row.articles for row in rows2])
 
 
 def test_join_with_select():
@@ -669,7 +744,9 @@ def test_nested_relationships():
 
     # more complex:
     role = Role.where(name="reader").join(
-        "users.bestie", "users.articles.final_editor", "users.articles.secondary_author"
+        "users.bestie",
+        "users.articles.final_editor",
+        "users.articles.secondary_author",
     )
 
     nested_article = role.first().users[2].articles[0]
@@ -681,26 +758,14 @@ def test_nested_relationships():
 
     # complex, inner:
     role_inner = Role.where(name="reader").join(
-        "users.bestie", "users.articles.final_editor", "users.articles.secondary_author", method="inner"
+        "users.bestie",
+        "users.articles.final_editor",
+        "users.articles.secondary_author",
+        method="inner",
     )
 
     # no final_editor -> inner join should fail:
     assert not role_inner.first()
-
-
-"""
-In production I noticed this bug:
-
-When joining nested data like `process = Process.join("pros_and_cons.product")`
-process.pros_and_cons[0].product # is fine
-process.pros_and_cons[1].product # is None
-while they both share the same `product_gid`
-This indicates that something goes wrong when collecting the nested data.
-`pros_and_cons` is very specific to that production use-case so please think of a more general example and write a test for it.
-1. define the required tables and relationships
-2. define the required data
-3. perform the query and check the results
-"""
 
 
 class City(TypedTable):


### PR DESCRIPTION
## Summary
Enhance relationship handling with lazy loading policies and explicit relationship control, providing better flexibility and performance optimization for data fetching.

## Changes

### New Features

**Lazy Loading Policies** (`lazy` parameter)
- `"forbid"` - Raise an error when accessing unjoined relationships (strictest, prevents N+1 queries)
- `"warn"` - Return empty value with RuntimeWarning (matches previous behavior)
- `"ignore"` - Return empty value silently
- `"tolerate"` - Fetch data on-demand with performance warning (new default)
- `"allow"` - Fetch data on-demand silently

Configure globally via `TypeDALConfig.lazy_policy` or per-relationship via `relationship(..., lazy="forbid")`.

**Explicit Relationships** (`explicit` parameter)
Mark relationships as only loading when explicitly requested:
```python
tags_tolerate = relationship(
    list["Tag"],
    on=...,
    lazy="tolerate",
    explicit=True  # only loaded when explicitly joined
)
```

### Enhanced `join()` API
- Now accepts `Relationship` instances directly: `Article.join(Article.tags, method="inner")`
- Handles mixed string/instance arguments: `Article.join("author", Article.tags)`
- Better error handling for conflicting `condition` and `on` parameters
- Respects `explicit=True` in bare `.join()` calls (only joins explicitly requested relationships)

### Improved Descriptor Behavior
- Added `__set_name__` to automatically track relationship field names
- Implements lazy loading with configurable policies in `__get__`
- Graceful fallback when lazy loading fails

### Configuration
- New `TypeDALConfig.lazy_policy` setting (default: `"tolerate"`)
- Can be set via `pyproject.toml` `[tool.typedal]` section
- Per-relationship override via `lazy` parameter

### Other Improvements
- Better error messages for relationship configuration conflicts
- Type annotation improvements throughout
- Added `__eq__` method to TypedTable instances for row-based comparison

## Testing
- Added comprehensive tests for all lazy loading policies
- Tests for explicit relationships
- Tests for direct Relationship instance joins
- Verified backward compatibility with existing join patterns

## Documentation

This release includes a comprehensive documentation update covering the changes in this release as well as several previous releases:

- **1. Getting Started** - Added references to configuration options and py4web setup
- **2. Defining Tables** - Updated with clearer navigation to the query building guide
- **3. Building Queries** - Enhanced with `.where()` examples, `.orderby()` usage, raw SQL expressions, and links to relationships documentation
- **4. Relationships** - Expanded with lazy loading policies, explicit relationships, alternative join syntax, and nested relationship examples
- **5. py4web & web2py** - (existing)
- **6. Migrations** - Streamlined with clearer minimal configuration and simplified instructions
- **7. Advanced Configuration** - New comprehensive guide covering all TypeDAL config options, multiple connections, environment variables, and lazy policies
- **8. Mixins** - Renamed from page 7, updated with modern examples and class method patterns
- Added cross-references between related documentation pages throughout