### PR TITLE
feat(query): add async iteration and windowed query results

### DIFF
--- a/docs/11_async.md
+++ b/docs/11_async.md
@@ -63,6 +63,9 @@ async for batch in Author.where(Author.name.startswith("A")).chunk_async(100):
 Each `chunk_async()` batch is fetched by a separate await. Outside a session, each batch is also a separate transaction,
 so a concurrent writer can become visible during the iteration. Wrap the loop in `async with db.session()` when all
 batches need to use the same transaction and snapshot.
+`chunk_async()` and `window()` cannot be combined with an existing `limitby`, because that sends mixed signals about
+whether the query should return one fixed slice or paginate through the complete result. Use `paginate_async()` when
+you need an explicitly bounded page or offset.
 
 ## Transactions
 

--- a/docs/11_async.md
+++ b/docs/11_async.md
@@ -1,7 +1,7 @@
 # 11. Async
 
 Every query method has an `*_async` twin: `collect_async()`, `insert_async()`, `count_async()`,
-`update_async()`, `delete_async()`, and so on. They do exactly what their sync counterparts do
+`update_async()`, `delete_async()`, `chunk_async()`, and so on. They do exactly what their sync counterparts do
 (same arguments, same return values, same relationships, caching, hooks and permissions), except
 that they do not block the event loop while the database is busy.
 
@@ -28,6 +28,41 @@ async def handler():
     total = await Author.count_async()
     return author, authors, total
 ```
+
+## Awaiting and iterating query builders
+
+Query builders can be awaited directly. This is shorthand for `collect_async()` and returns the same `TypedRows`
+result:
+
+```python
+authors = await Author.where(Author.name.startswith("A"))
+```
+
+Query builders also support asynchronous iteration. `async for` yields individual typed table instances:
+
+```python
+async for author in Author.where(Author.name.startswith("A")):
+    await notify(author)
+```
+
+By default, asynchronous iteration collects the complete result set before yielding its first row. Use `window()` to
+fetch the result in batches while keeping the row-by-row `async for` interface:
+
+```python
+async for author in Author.where(Author.name.startswith("A")).window(100):
+    await notify(author)
+```
+
+Use `chunk_async()` when the consumer should receive each batch as a `TypedRows[Author]` result instead:
+
+```python
+async for batch in Author.where(Author.name.startswith("A")).chunk_async(100):
+    await index_author_batch(batch)  # batch is TypedRows[Author]
+```
+
+Each `chunk_async()` batch is fetched by a separate await. Outside a session, each batch is also a separate transaction,
+so a concurrent writer can become visible during the iteration. Wrap the loop in `async with db.session()` when all
+batches need to use the same transaction and snapshot.
 
 ## Transactions
 

--- a/docs/3_building_queries.md
+++ b/docs/3_building_queries.md
@@ -284,6 +284,9 @@ for batch in Article.where(Article.published == True).chunk(100):
 `chunk_size` is the maximum number of rows in each `TypedRows[Article]` batch. The query is paginated repeatedly until
 an empty batch is returned. For example, with 250 matching articles and `chunk(100)`, the loop receives batches of 100,
 100, and 50 rows.
+These batching helpers cannot be combined with an existing `limitby`, because that sends mixed signals about whether
+the query should return one fixed slice or paginate through the complete result. Use `paginate()` when you need an
+explicitly bounded page or offset.
 Keep an explicit ordering when the database must return rows in a stable order:
 
 ```python

--- a/docs/3_building_queries.md
+++ b/docs/3_building_queries.md
@@ -156,31 +156,32 @@ For more details about relationships and joins, see [4. Relationships](./4_relat
 
 ### groupby & having
 
-Group query results by one or more fields, typically used with aggregate functions like `count()`, `sum()`, `avg()`, etc.
+Group query results by one or more fields, typically used with aggregate functions like `count()`, `sum()`, `avg()`,
+etc.
 Use `having` to filter the grouped results based on aggregate conditions.
 
 ```python
 # Basic grouping: count articles per author
 Article.select(Article.author, Article.id.count().with_alias("article_count"))
-    .groupby(Article.author)
-    .collect()
+.groupby(Article.author)
+.collect()
 
 # Group by multiple fields
 Sale.select(Sale.product, Sale.region, Sale.amount.sum().with_alias("total"))
-    .groupby(Sale.product, Sale.region)
-    .collect()
+.groupby(Sale.product, Sale.region)
+.collect()
 
 # Filter groups with having: only authors with more than 5 articles
 Article.select(Article.author, Article.id.count().with_alias("article_count"))
-    .groupby(Article.author)
-    .having(Article.id.count() > 5)
-    .collect()
+.groupby(Article.author)
+.having(Article.id.count() > 5)
+.collect()
 
 # Can be chained in any order
 School.groupby(School.id)
-    .having(Team.id.count() > 0)
-    .select(School.id, Team.id.count())
-    .collect()
+.having(Team.id.count() > 0)
+.select(School.id, Team.id.count())
+.collect()
 ```
 
 ### cache
@@ -214,7 +215,8 @@ In order to enable this functionality, TypeDAL adds a `before update` and `befor
 which manages the dependencies. You can disable this behavior by passing `cache_dependency=False` to `db.define`.
 Be aware doing this might break some caching functionality!
 
-**Note:** For caching function results (instead of just query results), see [9. Function Memoization](./9_memoization.md).
+**Note:** For caching function results (instead of just query results),
+see [9. Function Memoization](./9_memoization.md).
 
 ### permissions
 
@@ -249,6 +251,8 @@ The Query Builder has a few operations that don't return a new builder instance:
   be indexed by ID instead of a list index (e.g. `rows[15]` to get the row with ID 15)
 - paginate: this works similarly to `collect`, but returns a PaginatedRows instead, which has a `.next()`
   and `.previous()` method to easily load more pages.
+- chunk: iterate over the query results in `TypedRows` batches of a fixed size. Each batch is loaded separately, so this
+  is useful when the complete result set should not be held in memory at once.
 - collect_into: instantiate rows as another TypedTable model that is unbound or bound to the same table.
 - collect_or_fail: where `collect` may return an empty result, this variant will raise an error if there are no results.
 - execute: get the raw rows matching your query as returned by pydal, without entity mapping or relationship loading.
@@ -260,6 +264,59 @@ The Query Builder has a few operations that don't return a new builder instance:
 - delete: instead of selecting rows, delete those matching the current query (see [Delete](#delete))
 
 Additionally, you can directly call `.all()`, `.collect()`, `.count()`, `.first()` on a model (e.g. `User.all()`).
+
+#### Chunking and windowed iteration
+
+Use `chunk()` when you want to process a large result set in batches:
+
+```python
+from typedal import TypedRows
+
+
+def send_article_batch(batch: TypedRows[Article]) -> None:
+    print(len(batch))  # with 250 published articles, prints 100, 100, 50
+
+
+for batch in Article.where(Article.published == True).chunk(100):
+    send_article_batch(batch)
+```
+
+`chunk_size` is the maximum number of rows in each `TypedRows[Article]` batch. The query is paginated repeatedly until
+an empty batch is returned. For example, with 250 matching articles and `chunk(100)`, the loop receives batches of 100,
+100, and 50 rows.
+Keep an explicit ordering when the database must return rows in a stable order:
+
+```python
+for rows in Article.where(Article.published == True).orderby(Article.id).chunk(100):
+    archive(rows)
+```
+
+`window()` configures the same batching behavior for normal iteration over a query builder. It yields individual rows
+while fetching at most the configured number of rows per database round trip. As with the other query-builder methods,
+it can be called directly on a typed table or chained after another query-builder method:
+
+```python
+for article in Article.where(Article.published == True).window(100):
+    process(article)
+```
+
+Without `window()`, iterating a query builder collects the complete result set first.
+
+```python
+for article in Article.window(100):
+    process(article)
+```
+
+Typed-table methods such as `where()`, `select()`, and `window()` are convenience delegates that create or extend a
+`QueryBuilder`. A database field with the same name takes precedence over such a delegate on the typed table. For
+example, if `Article` has a field called `window`, use the query-builder form explicitly:
+
+```python
+from typedal import QueryBuilder
+
+for article in QueryBuilder(Article).window(100):
+    process(article)
+```
 
 #### collect_into example
 
@@ -334,4 +391,5 @@ person.delete_record()
 Need less-common query patterns (for example, using `QueryBuilder` on old-style pyDAL tables)?
 See [10. Advanced APIs](./10_advanced_apis.md).
 
-Calling these from async code? Every execution method has a non-blocking `*_async` twin - see [11. Async](./11_async.md).
+Calling these from async code? Every execution method has a non-blocking `*_async` twin -
+see [11. Async](./11_async.md).

--- a/src/typedal/asynchronous.py
+++ b/src/typedal/asynchronous.py
@@ -434,6 +434,7 @@ class BlockingAccessHandler(ExecutionHandler):
             f"the extra query. command: {command}",
             category=BlockingDatabaseAccessWarning,
             skip_file_prefixes=_SKIP_FRAMES,
+            stacklevel=2,
         )
 
 

--- a/src/typedal/cli.py
+++ b/src/typedal/cli.py
@@ -30,6 +30,7 @@ except ImportError as e:
         "to fix this.",
         source=e,
         category=RuntimeWarning,
+        stacklevel=2,
     )
     exit(127)  # command not found
 
@@ -226,7 +227,7 @@ def setup(
     data.pop("connection", None)
 
     # ignore any None:
-    old_contents["tool"]["typedal"] = {k: v for k, v in data.items() if v is not None}
+    old_contents["tool"]["typedal"] = {k: v for k, v in data.items() if v is not None}  # type: ignore
 
     with toml_path.open("w") as f:
         tomlkit.dump(old_contents, f)

--- a/src/typedal/config.py
+++ b/src/typedal/config.py
@@ -159,7 +159,7 @@ def _load_toml(path: str | bool | Path | None = True) -> tuple[str, AnyDict]:
 
         return str(toml_path) or "", t.cast(AnyDict, data["tool"]["typedal"])
     except Exception as e:
-        warnings.warn(f"Could not load typedal config toml: {e}", source=e)
+        warnings.warn(f"Could not load typedal config toml: {e}", source=e, stacklevel=2)
         return str(toml_path) or "", {}
 
 

--- a/src/typedal/core.py
+++ b/src/typedal/core.py
@@ -53,8 +53,8 @@ def _expression_subclasses() -> t.Iterator[type]:
     """
     Yield Expression and every (nested) subclass currently loaded, e.g. Field and TypedField.
     """
-    seen = {Expression}
-    stack = [Expression]
+    seen: set[type[Expression]] = {Expression}
+    stack: list[type[Expression]] = [Expression]
     while stack:
         for subclass in stack.pop().__subclasses__():
             if subclass not in seen:
@@ -476,7 +476,12 @@ class TypeDAL(_TypeDALBase):
                 delattr(self, tablename)
 
             if verbose:
-                warnings.warn(f"{model} could not be migrated, try faking", source=e, category=RuntimeWarning)
+                warnings.warn(
+                    f"{model} could not be migrated, try faking",
+                    source=e,
+                    category=RuntimeWarning,
+                    stacklevel=2,
+                )
 
             # try again:
             return self.define(model, migrate=self._migrate, fake_migrate=self._migrate, redefine=True)

--- a/src/typedal/define.py
+++ b/src/typedal/define.py
@@ -123,7 +123,10 @@ class TableDefinitionBuilder:
             self.class_map[table._rname] = cls  # table_model - sql name
             cls.__on_define__(self.db)
         else:
-            warnings.warn("db.define used without inheriting TypedTable. This could lead to strange problems!")
+            warnings.warn(
+                "db.define used without inheriting TypedTable. This could lead to strange problems!",
+                stacklevel=2,
+            )
 
         if not tablename.startswith("typedal_") and cache_dependency:
             from .caching import _remove_cache, remove_cache_for_table

--- a/src/typedal/mixins.py
+++ b/src/typedal/mixins.py
@@ -180,6 +180,7 @@ class SlugMixin(Mixin):
             warnings.warn(
                 "The 'slug_suffix' option is deprecated, use 'slug_suffix_length' instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
 
         slug_suffix = slug_suffix_length or kw.get("slug_suffix", 0)

--- a/src/typedal/query_builder.py
+++ b/src/typedal/query_builder.py
@@ -1392,6 +1392,9 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
             ```
         """
         # require_permission checked in .collect()
+        if "limitby" in self.select_kwargs:
+            raise ValueError("chunk() cannot be combined with an existing limitby")
+
         page = 1
 
         while rows := self.__paginate(chunk_size, page).collect():
@@ -1547,6 +1550,8 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
         need every page to come from the same snapshot.
         """
         # require_permission checked in .collect()
+        if "limitby" in self.select_kwargs:
+            raise ValueError("chunk_async() cannot be combined with an existing limitby")
 
         db = self._get_db()
         page = 1

--- a/src/typedal/query_builder.py
+++ b/src/typedal/query_builder.py
@@ -1222,7 +1222,18 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
         """
         You can start iterating a Query Builder object before calling collect, for ease of use.
         """
+        # fixme: integrate chunk ?
         yield from self.collect()
+
+    def __await__(self):
+        return self.collect_async().__await__()
+
+    async def __aiter__(self):
+        # fixme: integrate chunk ?
+        rows = await self.collect_async()
+        for row in rows:
+            yield row
+
 
     def __count(
         self,

--- a/src/typedal/query_builder.py
+++ b/src/typedal/query_builder.py
@@ -8,6 +8,7 @@ import datetime as dt
 import math
 import time
 import typing as t
+import warnings
 from collections import defaultdict
 
 from pydal.helpers.classes import SQLALL
@@ -45,6 +46,7 @@ from .types import (
     merge_permissions,
     require_permission,
 )
+from .warnings import UnusedWindowWarning
 
 
 class QueryBuilder[T_MetaInstance: _TypedTable](Select):
@@ -296,7 +298,7 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
             elif isinstance(query_part, (Query, Expression)):
                 subquery |= t.cast(Query, query_part)
             elif callable(query_part):
-                if result := query_part(self.model):  # ty: ignore[call-top-callable]
+                if result := query_part(self.model):
                     subquery |= result
             elif isinstance(query_part, dict):
                 subsubquery = DummyQuery()
@@ -661,6 +663,17 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
             return result
 
         query, select_args, select_kwargs = self._before_query(metadata, add_id=add_id)
+
+        window_size = metadata.get("window_size", None)
+        is_iterating = metadata.get("iterating", False)
+
+        if window_size is not None and is_iterating is not True:
+            warnings.warn(
+                "A window size was configured, but collect() was called directly. "
+                "Use iteration over the query builder to fetch rows in windows.",
+                stacklevel=2,
+                category=UnusedWindowWarning,
+            )
 
         metadata["sql"] = db(query)._select(*select_args, **select_kwargs)
 
@@ -1222,24 +1235,40 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
         """
         You can start iterating a Query Builder object before calling collect, for ease of use.
         """
-        # fixme: integrate chunk ?
-        yield from self.collect()
+        builder = self._extend(metadata={"iterating": True})
+        window_size = self.metadata.get("window_size", None)
+
+        if not window_size:
+            yield from builder.collect()
+            return
+
+        for chunk in builder.chunk(window_size):
+            yield from chunk
 
     def __await__(self):
         return self.collect_async().__await__()
 
     async def __aiter__(self):
-        # fixme: integrate chunk ?
-        rows = await self.collect_async()
-        for row in rows:
-            yield row
+        builder = self._extend(metadata={"iterating": True})
 
+        window_size = self.metadata.get("window_size", None)
+
+        if window_size:
+            async for chunk in builder.chunk_async(window_size):
+                for row in chunk:
+                    yield row
+        else:
+            rows = await builder.collect_async()
+            for row in rows:
+                yield row
+
+    def window(self, window_size: int) -> QueryBuilder[T_MetaInstance]:
+        return self._extend(metadata={"window_size": window_size})
 
     def __count(
         self,
         db: TypeDAL,
         distinct: t.Optional[bool] = None,
-        *,
         include_left_for_distinct: bool = True,
     ) -> Query:
         # internal, shared logic between .count and ._count
@@ -1362,7 +1391,7 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
                     pass
             ```
         """
-        require_permission(self._permissions, "read")
+        # require_permission checked in .collect()
         page = 1
 
         while rows := self.__paginate(chunk_size, page).collect():
@@ -1517,7 +1546,8 @@ class QueryBuilder[T_MetaInstance: _TypedTable](Select):
         writer can be visible halfway through the iteration; wrap it in `db.session()` if you
         need every page to come from the same snapshot.
         """
-        require_permission(self._permissions, "read")
+        # require_permission checked in .collect()
+
         db = self._get_db()
         page = 1
 

--- a/src/typedal/relationships.py
+++ b/src/typedal/relationships.py
@@ -110,7 +110,7 @@ class Relationship[To_Type]:
 
     @staticmethod
     def _error_duplicate_condition(condition: Condition, on: OnQuery) -> t.Never:
-        warnings.warn(f"Relation | Both specified! {condition=} {on=}")
+        warnings.warn(f"Relation | Both specified! {condition=} {on=}", stacklevel=2)
         raise ValueError("Please specify either a condition or an 'on' statement for this relationship!")
 
     def __repr__(self) -> str:
@@ -278,6 +278,7 @@ class Relationship[To_Type]:
                 f"Trying to access relationship '{self.name}' without joining. "
                 f"Did you forget to use .join('{self.name}')? Returning empty value.",
                 category=RuntimeWarning,
+                stacklevel=2,
             )
             return fallback_value
 
@@ -296,6 +297,7 @@ class Relationship[To_Type]:
                     "This performs an extra database query. "
                     f"Consider using .join('{self.name}') for better performance.",
                     category=RuntimeWarning,
+                    stacklevel=2,
                 )
 
             return builder.first()[self.name]  # type: ignore
@@ -304,6 +306,7 @@ class Relationship[To_Type]:
                 f"Failed to lazy load relationship '{self.name}': {e}",
                 category=RuntimeWarning,
                 source=e,
+                stacklevel=2,
             )
 
             return fallback_value
@@ -501,12 +504,12 @@ def to_relationship(
     try:
         condition = _generate_relationship_condition(cls, key, field)
     except Exception as e:  # pragma: no cover
-        warnings.warn("Could not generate Relationship condition", source=e)
+        warnings.warn("Could not generate Relationship condition", source=e, stacklevel=2)
         condition = None
 
     if not condition:  # pragma: no cover
         # something went wrong, not a valid relationship
-        warnings.warn(f"Invalid relationship for {cls.__name__}.{key}: {field}")
+        warnings.warn(f"Invalid relationship for {cls.__name__}.{key}: {field}", stacklevel=2)
         return None
 
     join = "left" if optional or t.get_origin(field) is list else "inner"

--- a/src/typedal/serializers/typescript.py
+++ b/src/typedal/serializers/typescript.py
@@ -31,7 +31,7 @@ class TypedDictRegistry(Singleton):
     def __init__(self) -> None:
         """Initialize the singleton registry and optional shared typtyp world."""
         self._types: dict[type, type[dict[str, t.Any]]] = {}
-        self._world = typtyp.World() if typtyp else None
+        self._world = typtyp.World() if typtyp else None  # type: ignore
         self._names: set[str] = set()
 
     @property
@@ -78,6 +78,7 @@ class TypedDictRegistry(Singleton):
         if world is None:  # pragma: ignore
             warnings.warn(
                 f"`{caller_name}` can not be used without the typescript extra. Please install `typedal[typescript]`",
+                stacklevel=2,
             )
             return ""
 

--- a/src/typedal/tables.py
+++ b/src/typedal/tables.py
@@ -138,6 +138,23 @@ class TableMeta(type):
         self._relationships = None
         self._permissions = None
 
+    def __getattribute__(self, col: str) -> t.Any:
+        """
+        Resolve bound table fields before metaclass convenience methods.
+
+        Annotation-only fields are not stored in the model class dictionary, so
+        normal class lookup would otherwise return a same-named method defined
+        on this metaclass. For example, a model may have a 'window' column
+        while this metaclass also provides 'window()'. The column takes
+        precedence on the model class; use 'QueryBuilder(Model).window()' to
+        call the query helper in that case.
+        """
+        table = type.__getattribute__(self, "_table")
+        if table is not None and col in table._fields:
+            return table[col]
+
+        return type.__getattribute__(self, col)
+
     def __getattr__(self, col: str) -> t.Optional[Field]:
         """
         Magic method used by TypedTableMeta to get a database field with dot notation on a class.
@@ -464,6 +481,12 @@ class TableMeta(type):
         See QueryBuilder.join!
         """
         return QueryBuilder(self).join(*fields, on=on, condition=condition, method=method, condition_and=condition_and)
+
+    def window(self: t.Type[T_MetaInstance], window_size: int) -> "QueryBuilder[T_MetaInstance]":
+        """
+        See QueryBuilder.window!
+        """
+        return QueryBuilder(self).window(window_size)
 
     def collect(self: t.Type[T_MetaInstance], verbose: bool = False) -> "TypedRows[T_MetaInstance]":
         """

--- a/src/typedal/types.py
+++ b/src/typedal/types.py
@@ -313,6 +313,8 @@ class Metadata(t.TypedDict):
     select_duration: t.NotRequired[float]
     relationships: t.NotRequired[set[str]]
     sql: t.NotRequired[str]
+    window_size: t.NotRequired[int]
+    iterating: t.NotRequired[bool]
 
 
 class FieldSettings(t.TypedDict, total=False):

--- a/src/typedal/warnings.py
+++ b/src/typedal/warnings.py
@@ -1,0 +1,5 @@
+"""Warning types emitted by TypeDAL."""
+
+
+class UnusedWindowWarning(RuntimeWarning):
+    """Warn when a window size is configured but the query is collected directly."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,10 @@
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def expect_no_warning(warning_type: type[Warning] | None = None) -> Iterator[None]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", warning_type or Warning)
+        yield

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -465,6 +465,14 @@ async def test_chunk_async_matches_sync_chunk(db_async: TypeDAL):
 
     assert [len(chunk) async for chunk in AsyncThingChunk.chunk_async(2)] == [2, 2, 1]
 
+    with pytest.raises(ValueError, match="limitby"):
+        async for _ in AsyncThingChunk.select(limitby=(1, 4)).chunk_async(2):
+            pass
+
+    with pytest.raises(ValueError, match="limitby"):
+        async for _ in AsyncThingChunk.select(limitby=(1, 4)).window(2):
+            pass
+
 
 @pytest.mark.asyncio
 async def test_column_async_matches_sync_column(db_async: TypeDAL):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -29,6 +29,7 @@ import pytest_asyncio
 from src.typedal import TypeDAL, TypedField, TypedTable
 from src.typedal.asynchronous import AsyncSession, BlockingDatabaseAccessWarning, ConnectionWorker
 from src.typedal.fields import DecimalField, JSONField
+from src.typedal import TypedRows
 
 
 class AsyncThingCached(TypedTable):
@@ -150,8 +151,10 @@ async def test_collect_async_matches_sync_collect(db_async: TypeDAL):
     AsyncThingParity.insert(name="gadget", qty=7)
     db.commit()
 
-    sync_rows = AsyncThingParity.where(AsyncThingParity.qty > 0).collect()
-    async_rows = await AsyncThingParity.where(AsyncThingParity.qty > 0).collect_async()
+    qb = AsyncThingParity.where(AsyncThingParity.qty > 0)
+
+    sync_rows = qb.collect()
+    async_rows = await qb.collect_async()
 
     assert len(async_rows) == len(sync_rows) == 2
 
@@ -163,6 +166,23 @@ async def test_collect_async_matches_sync_collect(db_async: TypeDAL):
         async_row = async_by_id[row_id]
         assert async_row.name == sync_row.name
         assert async_row.qty == sync_row.qty
+
+    # last b locking ones before not allowing warnings:
+    list_of_rows_sync = list(qb)
+    first_row_sync = qb.first()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", BlockingDatabaseAccessWarning)
+
+        rows_async = await qb
+        assert isinstance(rows_async, TypedRows), f"{type(rows_async)} unexpected"
+
+        assert list_of_rows_sync == list(rows_async)
+
+        async for row in qb:
+            break
+
+        assert row == first_row_sync == rows_async.first()
 
 
 @pytest.mark.asyncio
@@ -329,6 +349,7 @@ async def test_collect_async_with_relationships_matches_sync(db_async: TypeDAL):
     paginated = await AsyncThingRelMain.join("other").paginate_async(limit=1, page=1)
     assert len(paginated) == 1
     assert paginated.first().other.name == "parent"
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1088,6 +1088,16 @@ def test_window():
     assert isinstance(qb, QueryBuilder)
 
 
+def test_chunk_rejects_limitby():
+    _setup_data()
+
+    with pytest.raises(ValueError, match="limitby"):
+        list(TestQueryTable.select(limitby=(1, 4)).chunk(2))
+
+    with pytest.raises(ValueError, match="limitby"):
+        list(TestQueryTable.select(limitby=(1, 4)).window(2))
+
+
 @pytest.mark.asyncio
 async def test_window_async():
     _setup_data()

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -3,6 +3,8 @@ import pytest
 from src.typedal import QueryBuilder, TypeDAL, TypedField, TypedTable, relationship
 from src.typedal.fields import rname
 from src.typedal.types import Query, Field
+from src.typedal.warnings import UnusedWindowWarning
+from .helpers import expect_no_warning
 
 db = TypeDAL("sqlite:memory")
 
@@ -1044,3 +1046,64 @@ def test_groupby_having_on_table_class():
     assert "HAVING" in sql1
 
     assert builder1.execute() == builder2.execute()
+
+class QueryCounter:
+    count = 0
+
+    def __call__(self, _):
+        self.count += 1
+
+def test_window():
+    _setup_data()
+
+    window_size = 2
+    qb = TestRelationship.window(window_size)
+
+    with pytest.warns(UnusedWindowWarning):
+        qb.collect()
+
+    query_counter = QueryCounter()
+    db._before_collect.append(query_counter)
+
+    with expect_no_warning(UnusedWindowWarning):
+        for row in qb:
+            assert isinstance(row, TestRelationship)
+
+    expected_count = (TestRelationship.count() + window_size - 1) // window_size + 1
+    assert expected_count == query_counter.count
+
+
+    # test that table which has 'window' field has more prio than the method,
+    # and QueryBuilder(Table).window() still works:
+    @db.define()
+    class TableWithWindowField(TypedTable):
+        window: str
+
+    assert not isinstance(TestRelationship.window, Field)
+    assert isinstance(TableWithWindowField.window, Field), f"unexpected type {type(TableWithWindowField.window)}"
+
+    assert not isinstance(QueryBuilder(TableWithWindowField).window, Field)
+
+    qb = QueryBuilder(TableWithWindowField).window(10)
+    assert isinstance(qb, QueryBuilder)
+
+
+@pytest.mark.asyncio
+async def test_window_async():
+    _setup_data()
+
+    window_size = 2
+    qb = TestRelationship.window(window_size)
+
+    with pytest.warns(UnusedWindowWarning):
+        await qb.collect_async()
+
+    query_counter = QueryCounter()
+    db._before_collect.append(query_counter)
+
+    with expect_no_warning(UnusedWindowWarning):
+        async for row in qb:
+            assert isinstance(row, TestRelationship)
+
+    expected_count = (await TestRelationship.count_async() + window_size - 1) // window_size + 1
+    assert expected_count == query_counter.count


### PR DESCRIPTION
- **wip: first version of `await QueryBuilder` and `async for`**
- **feat(query): add sync and async windowed iteration**
- **fix(warnings): report warnings from caller locations**
- **docs: describe recent async/iter and window functionality**
- **fix: reject window()/chunk() in combination with select(limity=...) since it's mixed signals for different purposes**
